### PR TITLE
Download the param files from CloudFront

### DIFF
--- a/app/service/fetch-parameters-service.js
+++ b/app/service/fetch-parameters-service.js
@@ -12,7 +12,7 @@ const ProgressBar = require('electron-progressbar')
 const quickHashesConfigKey = 'resistanceParameters.quickHashes'
 const paramsFolderName = 'ResistanceParams'
 
-const sproutUrl = `https://s3.amazonaws.com/res-params`
+const sproutUrl = `https://d3idekp8vvpxdr.cloudfront.net`
 const sproutFiles = [
   { name: 'sprout-proving.key', checksum: "8bc20a7f013b2b58970cddd2e7ea028975c88ae7ceb9259a5344a16bc2c0eef7" },
   { name: 'sprout-verifying.key', checksum: "4bd498dae0aacfd8e98dc306338d017d9c08dd0918ead18172bd0aec2fc5df82" }


### PR DESCRIPTION
@iwuvjhdva @lukewegryn I set up a CloudFront distribution in front of the res-params bucket.  I'm seeing much faster downloads now when I test from an EC2 instances running in the eu-central-1 region (in Germany).  
We could add a better/more descriptive domain name for the CloudFront URL but that won't make a difference for download performance and is obviously something we can do later i.e. when the code base is open sourced

For now, can you try this out with your Mac client and tell me if the download speeds have improved?